### PR TITLE
Add compatibility with ctypes 0.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: Main workflow
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-version:
+          - 4.11.2
+          - 4.10.1
+          - 4.09.1
+          - 4.08.1
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      - run: opam pin add pci.dev . --no-action
+
+      - run: opam depext pci --yes --with-doc --with-test
+
+      - run: opam install . --deps-only --with-doc --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest

--- a/bindings/dune
+++ b/bindings/dune
@@ -1,4 +1,4 @@
 (library
  (name pci_bindings)
  (public_name pci.bindings)
- (libraries ctypes.stubs ctypes ctypes.foreign.threaded))
+ (libraries ctypes.stubs ctypes ctypes.foreign threads))

--- a/examples/lspci.ml
+++ b/examples/lspci.ml
@@ -43,7 +43,7 @@ let lspci_nnnDv pci_access =
   ( match devs with
   | [] ->
       ()
-  | d :: ds ->
+  | d :: _ ->
       let open Pci_dev in
       Printf.printf "Getting region sizes for device %04x:%02x:%02x.%d\n"
         d.domain d.bus d.dev d.func ;

--- a/lib/dune
+++ b/lib/dune
@@ -25,6 +25,7 @@
 (library
  (name pci)
  (public_name pci)
+ (flags (:standard -w -27-9))
  (foreign_stubs
   (language c)
   (names ffi_generated_stubs)

--- a/lib/pci.ml
+++ b/lib/pci.ml
@@ -74,8 +74,6 @@ let id x = x
 
 let maybe f = function Some x -> f x | None -> ()
 
-let scan_bus = B.pci_scan_bus
-
 let with_string ?(size = 1024) f =
   (* Using an ocaml string violates this rule from the ctypes FAQ:
    * string is unsuitable for binding to C functions that write

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,4 +1,5 @@
 (test
  (name test_pci)
  (deps dump.data)
+ (flags (:standard -w -35))
  (libraries pci oUnit))


### PR DESCRIPTION
Ctypes 0.18 removes the threaded and unthreaded libraries. Previously ctypes.foreign was supposed to choose the correct one between them, this is why the threads library is declared. From the github conversations I've read it's not clear whether it's needed or not since dune always uses -mt, but I'd rather be safe than sorry.

Build status can be seen in https://github.com/psafont/ocaml-pci/actions/runs/708100123

Note that it uses the default opam repo.


Compiling with cstubs 0.17.1 and cstubs-foreign 0.4.0 (using xs-opam master) I can see that the threaded version is still used (bolded for emphasis):

> Running[24]: (cd _build/default && /home/paus/.local/share/opam/toolstack/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o stubgen/ffi_types_stubgen.exe /home/paus/.local/share/opam/toolstack/lib/ocaml/unix.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ocaml /home/paus/.local/share/opam/toolstack/lib/ocaml/bigarray.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ocaml /home/paus/.local/share/opam/toolstack/lib/integers/integers.cmxa -I /home/paus/.local/share/opam/toolstack/lib/integers /home/paus/.local/share/opam/toolstack/lib/ctypes/ctypes.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ctypes /home/paus/.local/share/opam/toolstack/lib/ocaml/str.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ocaml /home/paus/.local/share/opam/toolstack/lib/ctypes/cstubs.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ctypes /home/paus/.local/share/opam/toolstack/lib/ocaml/threads/threads.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ocaml /home/paus/.local/share/opam/toolstack/lib/ctypes/ctypes-foreign-base.cmxa -I /home/paus/.local/share/opam/toolstack/lib/ctypes /home/paus/.local/share/opam/toolstack/lib/ctypes/**ctypes-foreign-threaded.cmxa** -I /home/paus/.local/share/opam/toolstack/lib/ctypes -I /home/paus/.local/share/opam/toolstack/lib/ctypes bindings/pci_bindings.cmxa stubgen/.ffi_stubgen.eobjs/native/dune__exe.cmx stubgen/.ffi_stubgen.eobjs/native/dune__exe__Ffi_types_stubgen.cmx)
